### PR TITLE
Align books recommend route to POST, clean .gitignore, and make notes test skip on missing deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The Gemini API key is already configured. For additional features, you may need:
 
 - `POST /tutor/chat` - AI tutor chat
 - `POST /notes/generate` - Generate notes from PDFs
-- `GET /books/` - Get book recommendations
+- `POST /books/recommend` - Get book recommendations
 - `POST /exam/predict` - Exam prediction
 - `GET /focus/session` - Focus mode session
 - `GET /sources/` - Learning sources

--- a/backend/routers/books.py
+++ b/backend/routers/books.py
@@ -5,6 +5,6 @@ from utils.auth import verify_token
 
 router = APIRouter()
 
-@router.get("/recommend")
+@router.post("/recommend")
 def recommend(request: BookRecommendationsRequest, user: dict = Depends(verify_token)):
     return {"recommendations": book_recommendations(f"Subject: {request.subject}, Level: {request.level}")}

--- a/backend/tests/test_notes.py
+++ b/backend/tests/test_notes.py
@@ -26,7 +26,7 @@ class TestNotes(unittest.TestCase):
                 from utils.auth import verify_token
             except ImportError:
                 # Fallback if imports fail due to complex dependencies
-                return
+                self.skipTest("Skipping notes test due to missing dependencies.")
 
             # Setup dependency override
             def mock_verify_token():

--- a/edu_ai/.gitignore
+++ b/edu_ai/.gitignore
@@ -39,20 +39,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-Failed to fetch
-
-app/(Dashboard)/notes/page.tsx (131:31) @ handleFileChange
-
-
-  129 |       const formData = new FormData();
-  130 |       formData.append("file", file);
-> 131 |       const uploadRes = await fetch("http://localhost:5000/api/upload_pdf", {
-      |                               ^
-  132 |         method: "POST",
-  133 |         body: formData,
-  134 |       });
-Call Stack
-9
-
-Show 8 ignore-listed frame(s)
-handleFileChange


### PR DESCRIPTION
### Motivation

- Remove accidental stack-trace / debug text that landed in the frontend `edu_ai/.gitignore` file. 
- Align the books recommendation API implementation with its documentation by using a `POST` endpoint for recommendations. 
- Make the notes unit test behavior explicit by skipping when complex dependencies cannot be imported instead of silently returning.

### Description

- Removed stray stack-trace/debug lines from `edu_ai/.gitignore`. 
- Updated `backend/routers/books.py` to use `@router.post("/recommend")` for the book recommendations endpoint. 
- Updated `README.md` to reflect the route as `POST /books/recommend`. 
- Changed `backend/tests/test_notes.py` to call `self.skipTest("Skipping notes test due to missing dependencies.")` when imports fail instead of returning early.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698262cd3aac83279624234016c1d050)